### PR TITLE
Fix ports and few more details

### DIFF
--- a/chart/templates/fms-orchestr8-config-nlp.yaml
+++ b/chart/templates/fms-orchestr8-config-nlp.yaml
@@ -39,4 +39,4 @@ data:
           hostname: language-detector-predictor
           port: 8000
         chunker_id: whole_doc_chunker
-        default_threshold: 0.5
+        default_threshold: 0.75

--- a/chart/templates/fms-orchestr8-config-nlp.yaml
+++ b/chart/templates/fms-orchestr8-config-nlp.yaml
@@ -10,7 +10,7 @@ data:
     openai: 
       service:
         hostname: llama-32-predictor
-        port: 80
+        port: 8080
     detectors:
       regex_competitor:
         type: text_contents
@@ -23,20 +23,20 @@ data:
         type: text_contents
         service:
           hostname: guardrails-detector-ibm-hap-predictor
-          port: 80
+          port: 8000
         chunker_id: whole_doc_chunker
         default_threshold: 0.5
       prompt_injection:
         type: text_contents
         service:
           hostname: prompt-injection-detector-predictor
-          port: 80
+          port: 8000
         chunker_id: whole_doc_chunker
         default_threshold: 0.5
       language_detection:
         type: text_contents
         service:
           hostname: language-detector-predictor
-          port: 80
+          port: 8000
         chunker_id: whole_doc_chunker
         default_threshold: 0.5

--- a/chart/templates/llm-llama32.yaml
+++ b/chart/templates/llm-llama32.yaml
@@ -24,7 +24,7 @@ spec:
         - '--model=/mnt/models'
         - '--served-model-name=llama32'
         - '--max-model-len'
-        - '512'
+        - '8096'
         - '--max-num-seqs'
         - '384'
         - '--max-num-batched-tokens'


### PR DESCRIPTION
This PR addresses following details:

- fixes ports in config-nlp to match detectors and llama32 ports
- increases default_threshold for language detection (helps to avoid lang confusion with very short messages)
- increases `max-model-len` to avoid easy limit hits