### PR TITLE
🍋‍🟩 fix: add namespace to dashboard for non admin users 🍋‍🟩

### DIFF
--- a/chart/dashboards/lemonade-dashboard.json
+++ b/chart/dashboards/lemonade-dashboard.json
@@ -19,10 +19,10 @@
             "span": 3,
             "targets": [
             {
-                "expr": "sum(guardrail_requests_total)",
+                "expr": "sum(guardrail_requests_total{namespace=\"$namespace\"})",
                 "format": "time_series",
-                "legendFormat": "",
-                "legendLink": null
+                "instant": true,
+                "refId": "A"
             }
             ],
             "title": "Total Requests",
@@ -54,10 +54,10 @@
             "span": 3,
             "targets": [
             {
-                "expr": "sum(guardrail_requests_total) - sum(guardrail_detections_total)",
+                "expr": "sum(guardrail_requests_total{namespace=\"$namespace\"}) - sum(guardrail_detections_total{namespace=\"$namespace\"})",
                 "format": "time_series",
-                "legendFormat": "",
-                "legendLink": null
+                "instant": true,
+                "refId": "A"
             }
             ],
             "title": "Approved Requests",
@@ -89,10 +89,10 @@
             "span": 3,
             "targets": [
             {
-                "expr": "sum(guardrail_detections_by_direction{direction=\"input\"})",
+                "expr": "sum(guardrail_detections_by_direction{namespace=\"$namespace\", direction=\"input\"})",
                 "format": "time_series",
-                "legendFormat": "",
-                "legendLink": null
+                "instant": true,
+                "refId": "A"
             }
             ],
             "title": "Input Blocked",
@@ -124,10 +124,10 @@
             "span": 3,
             "targets": [
             {
-                "expr": "sum(guardrail_detections_by_direction{direction=\"output\"})",
+                "expr": "sum(guardrail_detections_by_direction{namespace=\"$namespace\", direction=\"output\"})",
                 "format": "time_series",
-                "legendFormat": "",
-                "legendLink": null
+                "instant": true,
+                "refId": "A"
             }
             ],
             "title": "Output Blocked",
@@ -202,25 +202,25 @@
             "steppedLine": false,
             "targets": [
             {
-                "expr": "sum(guardrail_detections_by_detector{detector=\"hap\"})",
+                "expr": "sum(guardrail_detections_by_detector{namespace=\"$namespace\", detector=\"hap\"})",
                 "format": "time_series",
                 "legendFormat": "Swearing",
                 "legendLink": null
             },
             {
-                "expr": "sum(guardrail_detections_by_detector{detector=\"language_detection\"})",
+                "expr": "sum(guardrail_detections_by_detector{namespace=\"$namespace\", detector=\"language_detection\"})",
                 "format": "time_series",
                 "legendFormat": "Non-English",
                 "legendLink": null
             },
             {
-                "expr": "sum(guardrail_detections_by_detector{detector=\"prompt_injection\"})",
+                "expr": "sum(guardrail_detections_by_detector{namespace=\"$namespace\", detector=\"prompt_injection\"})",
                 "format": "time_series",
                 "legendFormat": "Jailbreak",
                 "legendLink": null
             },
             {
-                "expr": "sum(guardrail_detections_by_detector{detector=\"regex_competitor\"})",
+                "expr": "sum(guardrail_detections_by_detector{namespace=\"$namespace\", detector=\"regex_competitor\"})",
                 "format": "time_series",
                 "legendFormat": "Non Lemon",
                 "legendLink": null
@@ -297,13 +297,13 @@
             "steppedLine": false,
             "targets": [
             {
-                "expr": "sum(guardrail_detections_by_direction{direction=\"input\"})",
+                "expr": "sum(guardrail_detections_by_direction{namespace=\"$namespace\", direction=\"input\"})",
                 "format": "time_series",
                 "legendFormat": "Input Blocked",
                 "legendLink": null
             },
             {
-                "expr": "sum(guardrail_detections_by_direction{direction=\"output\"})",
+                "expr": "sum(guardrail_detections_by_direction{namespace=\"$namespace\", direction=\"output\"})",
                 "format": "time_series",
                 "legendFormat": "Output Blocked",
                 "legendLink": null
@@ -393,19 +393,19 @@
             "steppedLine": false,
             "targets": [
             {
-                "expr": "sum(guardrail_requests_total)",
+                "expr": "sum(guardrail_requests_total{namespace=\"$namespace\"})",
                 "format": "time_series",
                 "legendFormat": "Total Requests",
                 "legendLink": null
             },
             {
-                "expr": "sum(guardrail_requests_total) - sum(guardrail_detections_total)",
+                "expr": "sum(guardrail_requests_total{namespace=\"$namespace\"}) - sum(guardrail_detections_total{namespace=\"$namespace\"})",
                 "format": "time_series",
                 "legendFormat": "Approved",
                 "legendLink": null
             },
             {
-                "expr": "sum(guardrail_detections_total)",
+                "expr": "sum(guardrail_detections_total{namespace=\"$namespace\"})",
                 "format": "time_series",
                 "legendFormat": "Blocked",
                 "legendLink": null
@@ -477,6 +477,29 @@
         "refresh": 1,
         "regex": "",
         "type": "datasource"
+        },
+        {
+        "allValue": null,
+        "current": {
+            "text": "",
+            "value": ""
+        },
+        "datasource": "$datasource",
+        "hide": 2,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": "label_values(guardrail_requests_total, namespace)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
         }
     ]
     },


### PR DESCRIPTION
add $namespace to queries. this way normal users can see the dashboard if you set this on config map:

```bash
[console.openshift.io/odc-dashboard](http://console.openshift.io/odc-dashboard): "true"
```

and then give them "view" on the "lemonade-stand-assistant" namespace.