### PR TITLE
fix(chart): increase vLLM max-model-len from 512 to 4096

### DIFF
--- a/chart/templates/llm-llama32.yaml
+++ b/chart/templates/llm-llama32.yaml
@@ -25,7 +25,7 @@ spec:
         - '--model=/mnt/models'
         - '--served-model-name=llama32'
         - '--max-model-len'
-        - '512'
+        - '4096'
         - '--max-num-seqs'
         - '384'
         - '--max-num-batched-tokens'


### PR DESCRIPTION
## Summary
- The vLLM ServingRuntime hardcodes `--max-model-len 512`, which is too small for Llama 3.2 3B Instruct
- The system prompt alone consumes ~384 tokens, leaving virtually no room for user messages or completions
- vLLM returns 400 errors when prompt + max_tokens exceeds 512, causing the orchestrator to silently fail and the chat UI to show no response
- Bumps to `4096` which fits the system prompt plus multi-turn conversation comfortably on a single GPU

## How it was found
Discovered during automated E2E testing of the quickstart — the safe prompt "Why are lemons sour?" produced no response because the orchestrator's request to vLLM was rejected.

## Test plan
- [ ] Deploy with default Llama 3.2 model (Option B) and send a safe prompt — should get a natural language response
- [ ] Verify all four guardrails still trigger correctly (regex, HAP, language, prompt injection)
- [ ] Confirm KV cache memory usage is reasonable on a single GPU with 4096 context

🤖 Generated with [Claude Code](https://claude.com/claude-code)