### PR TITLE
Add Navigator installer, manifest, GPU tolerations, and port fixes

### DIFF
--- a/chart/templates/fms-orchestr8-config-nlp.yaml
+++ b/chart/templates/fms-orchestr8-config-nlp.yaml
@@ -16,7 +16,7 @@ data:
     openai: 
       service:
         hostname: {{ .Values.model.endpoint | default "llama-32-predictor" }}
-        port: {{ .Values.model.port | default "8080" }}
+        port: {{ .Values.model.port | default "80" }}
     detectors:
       regex_competitor:
         type: text_contents
@@ -29,14 +29,14 @@ data:
         type: text_contents
         service:
           hostname: guardrails-detector-ibm-hap-predictor
-          port: 8000
+          port: 80
         chunker_id: sentence
         default_threshold: 0.5
       prompt_injection:
         type: text_contents
         service:
           hostname: prompt-injection-detector-predictor
-          port: 8000
+          port: 80
         chunker_id: sentence
         default_threshold: 0.5
       language_detection:

--- a/chart/templates/ibm-hap-detector.yaml
+++ b/chart/templates/ibm-hap-detector.yaml
@@ -75,9 +75,7 @@ spec:
       storage:
         key: minio-data-connection-detector-models
         path: granite-guardian-hap-125m
-    {{- if .Values.detectors.hap.useGpu }}
+    {{- if and .Values.detectors.hap.useGpu .Values.gpuTolerations }}
     tolerations:
-      - effect: NoSchedule
-        key: nvidia.com/gpu
-        operator: Exists
+      {{- toYaml .Values.gpuTolerations | nindent 6 }}
     {{- end }}

--- a/chart/templates/llm-llama32.yaml
+++ b/chart/templates/llm-llama32.yaml
@@ -85,8 +85,8 @@ spec:
           nvidia.com/gpu: '1'
       runtime: llama-32
       storageUri: 'oci://quay.io/redhat-ai-services/modelcar-catalog:llama-3.2-3b-instruct'
+    {{- with .Values.gpuTolerations }}
     tolerations:
-      - effect: NoSchedule
-        key: nvidia.com/gpu
-        operator: Exists
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
 {{- end }}

--- a/chart/templates/prompt-injection-detector.yaml
+++ b/chart/templates/prompt-injection-detector.yaml
@@ -77,9 +77,7 @@ spec:
       storage:
         key: minio-data-connection-detector-models
         path: deberta-v3-base-prompt-injection-v2
-    {{- if .Values.detectors.promptInjection.useGpu }}
+    {{- if and .Values.detectors.promptInjection.useGpu .Values.gpuTolerations }}
     tolerations:
-      - effect: NoSchedule
-        key: nvidia.com/gpu
-        operator: Exists
+      {{- toYaml .Values.gpuTolerations | nindent 6 }}
     {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -6,6 +6,13 @@ model: {}
   # port: 443
   # api_key: my-api-key
 
+# GPU tolerations applied to all GPU-requiring pods (LLM, detectors with useGpu: true)
+# Override with cluster-specific taint keys if your GPU nodes use non-standard taints
+gpuTolerations:
+  - effect: NoSchedule
+    key: nvidia.com/gpu
+    operator: Exists
+
 # Detector configuration
 # Configure GPU usage and resources for each detector
 detectors:

--- a/installer/Dockerfile
+++ b/installer/Dockerfile
@@ -1,0 +1,43 @@
+# ============================================================================
+# Lemonade Stand Assistant Installer
+# ============================================================================
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+
+RUN microdnf install -y \
+    python3 \
+    python3-pip \
+    jq \
+    tar \
+    gzip \
+    bc \
+    openssl \
+    gettext \
+    && microdnf clean all
+
+# OpenShift CLI
+RUN curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz -o /tmp/oc.tar.gz && \
+    tar -xzvf /tmp/oc.tar.gz -C /usr/local/bin/ oc && \
+    chmod +x /usr/local/bin/oc && \
+    rm /tmp/oc.tar.gz
+
+# Helm CLI
+RUN curl -L https://get.helm.sh/helm-v3.14.0-linux-amd64.tar.gz | \
+    tar -xzv -C /tmp && \
+    mv /tmp/linux-amd64/helm /usr/local/bin/helm && \
+    chmod +x /usr/local/bin/helm && \
+    rm -rf /tmp/linux-amd64
+
+# Copy installer scripts
+COPY installer/entrypoint.sh /installer/entrypoint.sh
+COPY installer/lib/ /installer/lib/
+RUN chmod +x /installer/entrypoint.sh /installer/lib/*.sh
+
+# Copy Helm chart
+COPY chart/ /installer/chart/
+
+# Copy quickstart manifest
+COPY quickstart-manifest.yaml /installer/manifest.yaml
+
+WORKDIR /installer
+
+ENTRYPOINT ["/installer/entrypoint.sh"]

--- a/installer/build.sh
+++ b/installer/build.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# ============================================================================
+# Lemonade Stand Assistant Installer — Build Script
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+REGISTRY="quay.io/rh-ai-quickstart"
+IMAGE_NAME="lemonade-stand-assistant-installer"
+VERSION="1.0.0"
+FULL_IMAGE="${REGISTRY}/${IMAGE_NAME}:${VERSION}"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+info() { echo -e "${GREEN}✓${NC} $1"; }
+error() { echo -e "${RED}✗${NC} $1"; exit 1; }
+
+cd "$PROJECT_DIR"
+
+info "Checking required files..."
+REQUIRED_FILES=(
+  "installer/entrypoint.sh"
+  "installer/lib/install.sh"
+  "installer/lib/uninstall.sh"
+  "installer/lib/status.sh"
+  "installer/lib/check_pre_reqs.sh"
+  "installer/Dockerfile"
+  "quickstart-manifest.yaml"
+  "chart/Chart.yaml"
+)
+
+for file in "${REQUIRED_FILES[@]}"; do
+  if [[ ! -e "$file" ]]; then
+    error "Required file missing: $file"
+  fi
+done
+
+info "Building installer image: ${FULL_IMAGE}"
+podman build -t "${FULL_IMAGE}" -f installer/Dockerfile .
+
+info "Tagging as latest: ${REGISTRY}/${IMAGE_NAME}:latest"
+podman tag "${FULL_IMAGE}" "${REGISTRY}/${IMAGE_NAME}:latest"
+
+info "Build complete!"
+echo ""
+echo "Image: ${FULL_IMAGE}"
+echo "Also tagged: ${REGISTRY}/${IMAGE_NAME}:latest"
+
+if [[ "${1:-}" == "push" ]]; then
+  echo ""
+  info "Pushing to registry..."
+  podman push "${FULL_IMAGE}"
+  podman push "${REGISTRY}/${IMAGE_NAME}:latest"
+  info "Push complete!"
+  echo ""
+  echo "Image pushed to registry!"
+  echo ""
+  echo "Deploy to cluster:"
+  echo "  ./installer/deploy.sh check_pre_reqs <namespace> - Validate prerequisites"
+  echo "  ./installer/deploy.sh status <namespace>         - Check deployment status"
+  echo "  ./installer/deploy.sh install <namespace>        - Deploy installation"
+fi

--- a/installer/deploy.sh
+++ b/installer/deploy.sh
@@ -1,0 +1,378 @@
+#!/bin/bash
+# ============================================================================
+# Lemonade Stand Assistant — Deploy Script (Navigator Proxy)
+# ============================================================================
+
+set -euo pipefail
+
+REGISTRY="quay.io/rh-ai-quickstart"
+IMAGE_NAME="lemonade-stand-assistant-installer"
+VERSION="1.0.0"
+FULL_IMAGE="${REGISTRY}/${IMAGE_NAME}:${VERSION}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+info() { echo -e "${GREEN}✓${NC} $1"; }
+warn() { echo -e "${YELLOW}⚠${NC} $1"; }
+error() { echo -e "${RED}✗${NC} $1"; exit 1; }
+
+# ============================================================================
+# Job deployment function
+# ============================================================================
+
+deploy_job() {
+  local ACTION=$1
+  local TARGET_NAMESPACE=$2
+  local EXTRA_ENV=$3
+
+  local INSTALLER_NAMESPACE="default"
+
+  # --------------------------------------------------------------------------
+  # Create RBAC for installer
+  # --------------------------------------------------------------------------
+  info "Creating installer RBAC..."
+
+  cat <<RBAC | oc apply -f -
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: lemonade-stand-assistant-installer
+  namespace: ${INSTALLER_NAMESPACE}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: lemonade-stand-assistant-installer
+  namespace: ${INSTALLER_NAMESPACE}
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "configmaps"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: lemonade-stand-assistant-installer
+  namespace: ${INSTALLER_NAMESPACE}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: lemonade-stand-assistant-installer
+subjects:
+  - kind: ServiceAccount
+    name: lemonade-stand-assistant-installer
+    namespace: ${INSTALLER_NAMESPACE}
+RBAC
+
+  cat <<RBAC | oc apply -f -
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: lemonade-stand-assistant-installer-${TARGET_NAMESPACE}
+rules:
+  # Cluster-scoped read permissions
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list"]
+  - apiGroups: ["config.openshift.io"]
+    resources: ["clusterversions"]
+    verbs: ["get", "list"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list"]
+  - apiGroups: ["packages.operators.coreos.com"]
+    resources: ["packagemanifests"]
+    verbs: ["get", "list"]
+  # Namespace management
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "create", "delete"]
+  # Core resources
+  - apiGroups: [""]
+    resources: ["pods", "services", "secrets", "configmaps", "persistentvolumeclaims", "serviceaccounts"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Workloads
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets", "statefulsets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Jobs
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Routes
+  - apiGroups: ["route.openshift.io"]
+    resources: ["routes"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # RBAC
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["roles", "rolebindings"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Monitoring
+  - apiGroups: ["monitoring.coreos.com"]
+    resources: ["servicemonitors"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # KServe
+  - apiGroups: ["serving.kserve.io"]
+    resources: ["servingruntimes", "inferenceservices"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # TrustyAI
+  - apiGroups: ["trustyai.opendatahub.io"]
+    resources: ["guardrailsorchestrators"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: lemonade-stand-assistant-installer-${TARGET_NAMESPACE}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: lemonade-stand-assistant-installer-${TARGET_NAMESPACE}
+subjects:
+  - kind: ServiceAccount
+    name: lemonade-stand-assistant-installer
+    namespace: ${INSTALLER_NAMESPACE}
+RBAC
+
+  # --------------------------------------------------------------------------
+  # Create and monitor the Job
+  # --------------------------------------------------------------------------
+
+  local ACTION_SHORT=$(echo $ACTION | tr '[:upper:]' '[:lower:]' | tr '_' '-')
+  local TIMESTAMP=$(date +%s | tail -c 7)
+  local JOB_NAME="lsa-installer-${ACTION_SHORT}-${TIMESTAMP}"
+
+  info "Creating installer Job: $JOB_NAME"
+  info "Action: $ACTION"
+  info "Target namespace: $TARGET_NAMESPACE"
+  info "Installer namespace: $INSTALLER_NAMESPACE"
+  info "Image: ${FULL_IMAGE}"
+
+  cat <<EOF | oc apply -f -
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  namespace: ${INSTALLER_NAMESPACE}
+  labels:
+    app: lemonade-stand-assistant-installer
+    action: $(echo $ACTION | tr '[:upper:]' '[:lower:]' | tr '_' '-')
+    target-namespace: ${TARGET_NAMESPACE}
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app: lemonade-stand-assistant-installer
+        action: $(echo $ACTION | tr '[:upper:]' '[:lower:]' | tr '_' '-')
+    spec:
+      restartPolicy: Never
+      serviceAccountName: lemonade-stand-assistant-installer
+      containers:
+      - name: installer
+        image: ${FULL_IMAGE}
+        imagePullPolicy: Always
+        terminationMessagePolicy: FallbackToLogsOnError
+        env:
+        - name: ACTION
+          value: "${ACTION}"
+        - name: TARGET_NAMESPACE
+          value: "${TARGET_NAMESPACE}"
+        - name: JOB_NAME
+          value: "${JOB_NAME}"
+${EXTRA_ENV}
+EOF
+
+  echo ""
+  info "Job created! Monitoring logs..."
+  echo ""
+
+  sleep 3
+  oc logs -n "$INSTALLER_NAMESPACE" -f "job/${JOB_NAME}" 2>/dev/null || {
+    warn "Job may still be starting. Check logs with:"
+    echo "  oc logs -n $INSTALLER_NAMESPACE -f job/${JOB_NAME}"
+  }
+
+  # --------------------------------------------------------------------------
+  # Wait for Job completion
+  # --------------------------------------------------------------------------
+  echo ""
+  info "Waiting for Job to complete..."
+
+  WAIT_COUNT=0
+  MAX_WAIT=240
+  while [[ $WAIT_COUNT -lt $MAX_WAIT ]]; do
+    JOB_COMPLETE=$(oc get job -n "$INSTALLER_NAMESPACE" "${JOB_NAME}" -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' 2>/dev/null)
+    JOB_FAILED=$(oc get job -n "$INSTALLER_NAMESPACE" "${JOB_NAME}" -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null)
+
+    if [[ "$JOB_COMPLETE" == "True" ]]; then
+      info "Job completed successfully"
+      break
+    elif [[ "$JOB_FAILED" == "True" ]]; then
+      warn "Job failed. Check logs above for details."
+      break
+    fi
+
+    sleep 5
+    WAIT_COUNT=$((WAIT_COUNT + 1))
+  done
+
+  if [[ $WAIT_COUNT -eq $MAX_WAIT ]]; then
+    warn "Job did not complete within 20 minutes"
+    echo "  Check status: oc get job -n $INSTALLER_NAMESPACE ${JOB_NAME}"
+  fi
+
+  # --------------------------------------------------------------------------
+  # Retrieve termination message
+  # --------------------------------------------------------------------------
+  TERM_MSG=""
+  POD_NAME=$(oc get pods -n "$INSTALLER_NAMESPACE" -l "job-name=${JOB_NAME}" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+  if [[ -n "$POD_NAME" ]]; then
+    TERM_MSG=$(oc get pod -n "$INSTALLER_NAMESPACE" "$POD_NAME" -o jsonpath='{.status.containerStatuses[0].state.terminated.message}' 2>/dev/null)
+  fi
+  if [[ -z "$TERM_MSG" ]]; then
+    TERM_MSG=$(oc get job -n "$INSTALLER_NAMESPACE" "${JOB_NAME}" -o jsonpath='{.metadata.annotations.lemonade-stand-assistant-installer/termination-message}' 2>/dev/null)
+  fi
+  if [[ -n "$TERM_MSG" ]]; then
+    echo ""
+    info "Termination message:"
+    echo "  $TERM_MSG"
+  fi
+
+  echo ""
+  info "Job complete! Check status with:"
+  echo "  oc get job -n $INSTALLER_NAMESPACE ${JOB_NAME}"
+  echo "  oc describe job -n $INSTALLER_NAMESPACE ${JOB_NAME}"
+
+  # --------------------------------------------------------------------------
+  # Clean up installer RBAC
+  # --------------------------------------------------------------------------
+  info "Cleaning up installer RBAC..."
+
+  oc delete serviceaccount lemonade-stand-assistant-installer -n default --ignore-not-found=true 2>/dev/null || true
+  oc delete role lemonade-stand-assistant-installer -n default --ignore-not-found=true 2>/dev/null || true
+  oc delete rolebinding lemonade-stand-assistant-installer -n default --ignore-not-found=true 2>/dev/null || true
+  oc delete secret -l "kubernetes.io/service-account.name=lemonade-stand-assistant-installer" -n default --ignore-not-found=true 2>/dev/null || true
+
+  oc delete clusterrolebinding "lemonade-stand-assistant-installer-${TARGET_NAMESPACE}" --ignore-not-found=true 2>/dev/null || true
+  oc delete clusterrole "lemonade-stand-assistant-installer-${TARGET_NAMESPACE}" --ignore-not-found=true 2>/dev/null || true
+}
+
+# ============================================================================
+# Main case statement
+# ============================================================================
+
+case "${1:-}" in
+  check_pre_reqs)
+    NAMESPACE="${2:-${NAMESPACE:-}}"
+    [[ -z "$NAMESPACE" ]] && error "Namespace required. Usage: ./deploy.sh check_pre_reqs <namespace>"
+    deploy_job "CHECK_PRE_REQS" "$NAMESPACE" ""
+    ;;
+
+  status)
+    NAMESPACE="${2:-${NAMESPACE:-}}"
+    [[ -z "$NAMESPACE" ]] && error "Namespace required. Usage: ./deploy.sh status <namespace>"
+    deploy_job "STATUS" "$NAMESPACE" ""
+    ;;
+
+  install)
+    NAMESPACE="${2:-${NAMESPACE:-}}"
+    [[ -z "$NAMESPACE" ]] && error "Namespace required. Usage: ./deploy.sh install <namespace>"
+
+    INSTALL_ENV="        - name: INSTALL_MODE
+          value: \"demo\""
+
+    # Prompt for MaaS mode configuration
+    read -rp "Use external model endpoint (MaaS mode)? [y/N]: " USE_MAAS
+    if [[ "$USE_MAAS" == "y" || "$USE_MAAS" == "Y" ]]; then
+      read -rp "Model name: " MODEL_NAME
+      read -rp "Model endpoint (hostname only): " MODEL_ENDPOINT
+      read -rp "Model port [443]: " MODEL_PORT
+      MODEL_PORT="${MODEL_PORT:-443}"
+      read -rsp "Model API key: " MODEL_API_KEY
+      echo ""
+
+      INSTALL_ENV="        - name: INSTALL_MODE
+          value: \"demo\"
+        - name: MODEL_NAME
+          value: \"${MODEL_NAME}\"
+        - name: MODEL_ENDPOINT
+          value: \"${MODEL_ENDPOINT}\"
+        - name: MODEL_PORT
+          value: \"${MODEL_PORT}\"
+        - name: MODEL_API_KEY
+          value: \"${MODEL_API_KEY}\""
+    fi
+
+    # Prompt for GPU taint key override
+    echo ""
+    echo "GPU tolerations control which tainted nodes GPU pods can schedule on."
+    echo "Press Enter to auto-detect from cluster nodes, or provide a comma-separated"
+    echo "list of taint keys to override (e.g., 'g5-gpu,g6e-gpu')."
+    read -rp "GPU taint keys [auto-detect]: " GPU_TAINT_KEYS
+
+    if [[ -n "$GPU_TAINT_KEYS" ]]; then
+      local gpu_json="["
+      local first=true
+      IFS=',' read -ra KEYS <<< "$GPU_TAINT_KEYS"
+      for key in "${KEYS[@]}"; do
+        key=$(echo "$key" | tr -d ' ')
+        [[ -z "$key" ]] && continue
+        if [[ "$first" == "true" ]]; then
+          first=false
+        else
+          gpu_json+=","
+        fi
+        gpu_json+="{\"effect\":\"NoSchedule\",\"key\":\"${key}\",\"operator\":\"Exists\"}"
+      done
+      gpu_json+="]"
+      INSTALL_ENV="${INSTALL_ENV}
+        - name: GPU_TOLERATIONS
+          value: '${gpu_json}'"
+    fi
+
+    deploy_job "INSTALL" "$NAMESPACE" "$INSTALL_ENV"
+    ;;
+
+  uninstall_keep_data)
+    NAMESPACE="${2:-${NAMESPACE:-}}"
+    [[ -z "$NAMESPACE" ]] && error "Namespace required. Usage: ./deploy.sh uninstall_keep_data <namespace>"
+    deploy_job "UNINSTALL_KEEP_DATA" "$NAMESPACE" ""
+    ;;
+
+  uninstall_delete_all)
+    NAMESPACE="${2:-${NAMESPACE:-}}"
+    [[ -z "$NAMESPACE" ]] && error "Namespace required. Usage: ./deploy.sh uninstall_delete_all <namespace>"
+    deploy_job "UNINSTALL_DELETE_ALL" "$NAMESPACE" ""
+    ;;
+
+  "")
+    echo "Lemonade Stand Assistant Installer - Deploy Jobs to Cluster"
+    echo ""
+    echo "Usage: ./deploy.sh <action> <namespace>"
+    echo ""
+    echo "Actions:"
+    echo "  check_pre_reqs <namespace>          - Validate prerequisites"
+    echo "  status <namespace>                   - Check deployment status"
+    echo "  install <namespace>                  - Deploy installation"
+    echo "  uninstall_keep_data <namespace>      - Uninstall (keep data)"
+    echo "  uninstall_delete_all <namespace>     - Uninstall (delete all)"
+    echo ""
+    echo "Image: ${FULL_IMAGE}"
+    ;;
+
+  *)
+    error "Unknown action: $1"
+    ;;
+esac

--- a/installer/entrypoint.sh
+++ b/installer/entrypoint.sh
@@ -1,0 +1,242 @@
+#!/bin/bash
+# ============================================================================
+# Lemonade Stand Assistant Installer Entrypoint
+# ============================================================================
+
+set -euo pipefail
+
+source /installer/lib/check_pre_reqs.sh
+source /installer/lib/install.sh
+source /installer/lib/upgrade.sh
+source /installer/lib/status.sh
+source /installer/lib/uninstall.sh
+
+# ============================================================================
+# DO NOT MODIFY: Termination message and log capture infrastructure
+# ============================================================================
+
+_TERMINATION_STATUS=""
+_TERMINATION_MESSAGE=""
+_LOG_FILE="/tmp/installer-output.log"
+: > "$_LOG_FILE"
+
+exec 3>&1 4>&2
+exec > >(tee -a "$_LOG_FILE") 2> >(tee -a "$_LOG_FILE" >&2)
+
+log_status() {
+  local status=$1
+  local phase=$2
+  local message=$3
+  echo "{\"status\":\"$status\",\"phase\":\"$phase\",\"message\":\"$message\"}"
+}
+
+log_success() {
+  local endpoints=$1
+  _TERMINATION_STATUS="success"
+  _TERMINATION_MESSAGE=""
+  echo "{\"status\":\"success\",\"endpoints\":$endpoints}"
+}
+
+log_error() {
+  local message=$1
+  _TERMINATION_STATUS="error"
+  _TERMINATION_MESSAGE="$message"
+  echo "{\"status\":\"error\",\"message\":\"$message\"}" >&2
+  exit 1
+}
+
+log_prerequisites_failed() {
+  local missing_json=$1
+  _TERMINATION_STATUS="prerequisites_failed"
+  _TERMINATION_MESSAGE="$missing_json"
+  echo "{\"status\":\"prerequisites_failed\",\"missing\":$missing_json}" >&2
+  exit 2
+}
+
+cleanup_installer_rbac() {
+  log_status "running" "cleanup" "Installer cleanup complete"
+}
+
+# ============================================================================
+# DO NOT MODIFY: Log ConfigMap persistence
+# ============================================================================
+
+write_log_configmap() {
+  local job_name="${JOB_NAME:-unknown}"
+  local cm_name="lemonade-stand-assistant-installer-log-${job_name}"
+  local target_ns="${TARGET_NAMESPACE:-unknown}"
+  local expires_at
+  expires_at=$(date -u -d "+7 days" '+%Y-%m-%d' 2>/dev/null || \
+               date -u -v+7d '+%Y-%m-%d' 2>/dev/null || \
+               echo "unknown")
+
+  local log_content
+  log_content=$(tail -c 51200 "$_LOG_FILE" 2>/dev/null || echo "")
+
+  if [[ -z "$log_content" ]]; then
+    return 0
+  fi
+
+  local log_tmpfile="/tmp/installer-log-data.txt"
+  echo "$log_content" > "$log_tmpfile"
+
+  oc create configmap "$cm_name" \
+    --namespace default \
+    --from-file=log="$log_tmpfile" 2>/dev/null || { true; return 0; }
+
+  oc label configmap "$cm_name" \
+    --namespace default \
+    --overwrite \
+    "app=lemonade-stand-assistant-installer" \
+    "target-namespace=${target_ns}" \
+    "lemonade-stand-assistant-installer/expires-at=${expires_at}" 2>&1 || true
+}
+
+# ============================================================================
+# DO NOT MODIFY: Termination message + Job annotation
+# ============================================================================
+
+write_termination_message() {
+  local exit_code=$1
+  local status="${_TERMINATION_STATUS}"
+
+  if [[ -z "$status" ]]; then
+    case "$exit_code" in
+      0) status="success" ;;
+      2) status="prerequisites_failed" ;;
+      *) status="error" ;;
+    esac
+  fi
+
+  local recent_logs
+  recent_logs=$(tail -10 "$_LOG_FILE" 2>/dev/null | head -c 2000 || echo "")
+  recent_logs="${recent_logs//\\/\\\\}"
+  recent_logs="${recent_logs//\"/\\\"}"
+  recent_logs="${recent_logs//$'\n'/\\n}"
+
+  local job_name="${JOB_NAME:-unknown}"
+  local cm_name="lemonade-stand-assistant-installer-log-${job_name}"
+  local action="${ACTION:-unknown}"
+  local namespace="${TARGET_NAMESPACE:-unknown}"
+
+  local message=""
+  case "$status" in
+    success)
+      message="{\"status\":\"success\",\"action\":\"${action}\",\"namespace\":\"${namespace}\",\"logConfigMap\":{\"name\":\"${cm_name}\",\"namespace\":\"default\"}}"
+      ;;
+    prerequisites_failed)
+      message="{\"status\":\"prerequisites_failed\",\"action\":\"${action}\",\"namespace\":\"${namespace}\",\"missing\":${_TERMINATION_MESSAGE:-[]},\"logConfigMap\":{\"name\":\"${cm_name}\",\"namespace\":\"default\"}}"
+      ;;
+    error)
+      local err_msg="${_TERMINATION_MESSAGE:-Unexpected failure (exit code $exit_code)}"
+      err_msg="${err_msg//\\/\\\\}"
+      err_msg="${err_msg//\"/\\\"}"
+      err_msg="${err_msg//$'\n'/\\n}"
+      message="{\"status\":\"error\",\"action\":\"${action}\",\"namespace\":\"${namespace}\",\"message\":\"${err_msg}\",\"recentLogs\":\"${recent_logs}\",\"logConfigMap\":{\"name\":\"${cm_name}\",\"namespace\":\"default\"}}"
+      ;;
+  esac
+
+  printf '%.4096s' "$message" > /dev/termination-log 2>/dev/null || true
+
+  if [[ -n "$job_name" && "$job_name" != "unknown" ]]; then
+    oc annotate job "$job_name" \
+      --namespace default \
+      --overwrite \
+      "lemonade-stand-assistant-installer/termination-message=$message" 2>/dev/null || true
+  fi
+}
+
+# ============================================================================
+# DO NOT MODIFY: EXIT trap
+# ============================================================================
+
+cleanup_on_exit() {
+  local exit_code=$?
+  exec 1>&3 2>&4 3>&- 4>&-
+  sleep 0.2
+  write_termination_message "$exit_code" 2>&1 | tee -a "$_LOG_FILE"
+  if [[ "$exit_code" -ne 2 ]]; then
+    cleanup_installer_rbac 2>&1 | tee -a "$_LOG_FILE"
+  fi
+  write_log_configmap
+}
+trap cleanup_on_exit EXIT
+
+# ============================================================================
+# Validation
+# ============================================================================
+
+: "${ACTION:?ACTION must be set (CHECK_PRE_REQS, STATUS, INSTALL, UNINSTALL_DELETE_ALL, UNINSTALL_KEEP_DATA)}"
+: "${TARGET_NAMESPACE:?TARGET_NAMESPACE must be set}"
+: "${INSTALL_MODE:=demo}"
+
+case "$ACTION" in
+  UPGRADE)
+    log_error "Deployment Action (UPGRADE) not supported."
+    ;;
+esac
+
+if [[ "$INSTALL_MODE" != "demo" ]]; then
+  log_error "Installation mode ($INSTALL_MODE) not supported. Only 'demo' mode is currently supported."
+fi
+
+# ============================================================================
+# Main action routing
+# ============================================================================
+
+case "$ACTION" in
+  CHECK_PRE_REQS)
+    log_status "running" "validating" "Validating prerequisites..."
+    check_prerequisites || exit 2
+    log_status "success" "validating" "All prerequisites satisfied"
+    log_success "[]"
+    ;;
+
+  STATUS)
+    log_status "running" "verifying" "Verifying quickstart deployment status..."
+    verify_deployment
+    log_status "success" "verifying" "Verification complete"
+    log_success "[]"
+    ;;
+
+  INSTALL)
+    log_status "running" "validating" "Validating prerequisites..."
+    check_prerequisites || exit 2
+
+    log_status "running" "deploying" "Installing in $INSTALL_MODE mode..."
+    deploy_quickstart
+
+    log_status "running" "checking-status" "Waiting for pods to be ready..."
+    check_deployment_status
+
+    log_status "running" "finalizing" "Retrieving endpoints..."
+    ENDPOINTS=$(get_endpoints)
+    log_success "$ENDPOINTS"
+    ;;
+
+  UNINSTALL_DELETE_ALL)
+    log_status "running" "uninstalling" "Removing quickstart and all data..."
+    cleanup_quickstart "delete-all"
+
+    log_status "running" "verifying" "Verifying clean uninstallation..."
+    verify_deployment
+    log_success "[]"
+    ;;
+
+  UNINSTALL_KEEP_DATA)
+    log_status "running" "uninstalling" "Removing quickstart (keeping data volumes)..."
+    cleanup_quickstart "keep-data"
+
+    log_status "running" "verifying" "Verifying uninstallation (data preserved)..."
+    verify_deployment
+    log_success "[]"
+    ;;
+
+  UPGRADE)
+    log_error "Deployment Action (UPGRADE) not supported."
+    ;;
+
+  *)
+    log_error "Invalid ACTION: $ACTION (must be CHECK_PRE_REQS, STATUS, INSTALL, UNINSTALL_DELETE_ALL, UNINSTALL_KEEP_DATA)"
+    ;;
+esac

--- a/installer/lib/check_pre_reqs.sh
+++ b/installer/lib/check_pre_reqs.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+# ============================================================================
+# Lemonade Stand Assistant — Prerequisites Check
+# ============================================================================
+
+check_prerequisites() {
+  local missing=()
+
+  # --------------------------------------------------------------------------
+  # OpenShift version
+  # --------------------------------------------------------------------------
+  echo "Checking OpenShift version..."
+  local ocp_version
+  ocp_version=$(oc get clusterversion version -o jsonpath='{.status.desired.version}' 2>/dev/null || echo "")
+  if [[ -z "$ocp_version" ]]; then
+    missing+=("{\"name\":\"OpenShift Version\",\"reason\":\"Could not determine OpenShift version\"}")
+  else
+    echo "  OpenShift version: $ocp_version"
+    local required_version="4.16"
+    local ocp_major ocp_minor req_major req_minor
+    ocp_major=$(echo "$ocp_version" | cut -d. -f1)
+    ocp_minor=$(echo "$ocp_version" | cut -d. -f2)
+    req_major=$(echo "$required_version" | cut -d. -f1)
+    req_minor=$(echo "$required_version" | cut -d. -f2)
+    if [[ "$ocp_major" -lt "$req_major" ]] || { [[ "$ocp_major" -eq "$req_major" ]] && [[ "$ocp_minor" -lt "$req_minor" ]]; }; then
+      missing+=("{\"name\":\"OpenShift Version\",\"reason\":\"Requires >= $required_version, found $ocp_version\"}")
+    fi
+  fi
+
+  # --------------------------------------------------------------------------
+  # Required CRDs
+  # --------------------------------------------------------------------------
+  echo "Checking required CRDs..."
+
+  local required_crds=(
+    "servingruntimes.serving.kserve.io"
+    "inferenceservices.serving.kserve.io"
+    "guardrailsorchestrators.trustyai.opendatahub.io"
+  )
+
+  for crd in "${required_crds[@]}"; do
+    if oc get crd "$crd" &>/dev/null; then
+      echo "  ✓ CRD found: $crd"
+    else
+      missing+=("{\"name\":\"CRD: $crd\",\"reason\":\"Custom Resource Definition not found. Ensure the required operator is installed.\"}")
+    fi
+  done
+
+  # --------------------------------------------------------------------------
+  # Required operators
+  # --------------------------------------------------------------------------
+  echo "Checking required operators..."
+
+  # Check RHOAI via KServe CRDs (more reliable than CSV listing which requires extra RBAC)
+  if oc get crd inferenceservices.serving.kserve.io &>/dev/null && \
+     oc get crd servingruntimes.serving.kserve.io &>/dev/null; then
+    echo "  ✓ Red Hat OpenShift AI operator found (KServe CRDs present)"
+  else
+    missing+=("{\"name\":\"Red Hat OpenShift AI\",\"reason\":\"Operator not installed. Install from OperatorHub.\"}")
+  fi
+
+  # Check TrustyAI via GuardrailsOrchestrator CRD
+  if oc get crd guardrailsorchestrators.trustyai.opendatahub.io &>/dev/null; then
+    echo "  ✓ TrustyAI component found (GuardrailsOrchestrator CRD present)"
+  else
+    missing+=("{\"name\":\"TrustyAI\",\"reason\":\"TrustyAI component not enabled in Red Hat OpenShift AI. Enable TrustyAI in the DataScienceCluster configuration.\"}")
+  fi
+
+  # --------------------------------------------------------------------------
+  # Storage classes
+  # --------------------------------------------------------------------------
+  echo "Checking storage classes..."
+  local rwo_classes
+  rwo_classes=$(oc get storageclasses -o json 2>/dev/null | jq -r '.items[] | select(.metadata.annotations["storageclass.kubernetes.io/is-default-class"]=="true" or true) | .metadata.name' 2>/dev/null || echo "")
+  if [[ -n "$rwo_classes" ]]; then
+    echo "  ✓ Storage classes available"
+  else
+    missing+=("{\"name\":\"Storage Class\",\"reason\":\"No storage classes found. A ReadWriteOnce storage class is required for MinIO PVC (50Gi).\"}")
+  fi
+
+  # --------------------------------------------------------------------------
+  # Node resources
+  # --------------------------------------------------------------------------
+  echo "Checking node resources..."
+  local total_cpu total_memory
+  total_cpu=$(oc get nodes -o json 2>/dev/null | jq '[.items[].status.allocatable.cpu // "0" | if test("m$") then (gsub("m$";"") | tonumber / 1000) else tonumber end] | add | round' 2>/dev/null || echo "0")
+  total_memory=$(oc get nodes -o json 2>/dev/null | jq '[.items[].status.allocatable.memory // "0" | gsub("Ki$";"") | tonumber / 1048576] | add | round' 2>/dev/null || echo "0")
+
+  if [[ -n "$total_cpu" ]] && (( $(echo "$total_cpu >= 9" | bc -l 2>/dev/null || echo "0") )); then
+    echo "  ✓ CPU: ${total_cpu} vCPU available (minimum 9 required)"
+  else
+    missing+=("{\"name\":\"CPU Resources\",\"reason\":\"Minimum 9 vCPU required across cluster nodes. Found: ${total_cpu:-unknown}\"}")
+  fi
+
+  if [[ -n "$total_memory" ]] && (( $(echo "$total_memory >= 33" | bc -l 2>/dev/null || echo "0") )); then
+    echo "  ✓ Memory: ${total_memory} GiB available (minimum 33 required)"
+  else
+    missing+=("{\"name\":\"Memory Resources\",\"reason\":\"Minimum 33 GiB memory required across cluster nodes. Found: ${total_memory:-unknown} GiB\"}")
+  fi
+
+  # --------------------------------------------------------------------------
+  # GPU (informational — only required for default model mode)
+  # --------------------------------------------------------------------------
+  echo "Checking GPU resources..."
+  local gpu_count
+  gpu_count=$(oc get nodes -o json 2>/dev/null | jq '[.items[].status.allocatable["nvidia.com/gpu"] // "0" | tonumber] | add' 2>/dev/null || echo "0")
+  if [[ "$gpu_count" -gt 0 ]]; then
+    echo "  ✓ GPU: $gpu_count NVIDIA GPU(s) available"
+
+    local taint_keys
+    taint_keys=$(oc get nodes -o json 2>/dev/null | \
+      jq -r '[.items[] | select(.status.allocatable["nvidia.com/gpu"] // "0" | tonumber > 0) | .spec.taints // [] | .[] | select(.effect == "NoSchedule") | .key] | unique | .[]' 2>/dev/null || echo "")
+    if [[ -n "$taint_keys" ]]; then
+      echo "  GPU node taint keys detected:"
+      while IFS= read -r key; do
+        [[ -n "$key" ]] && echo "    - $key"
+      done <<< "$taint_keys"
+      echo "  The installer will auto-detect these during install, or you can override with custom keys."
+    else
+      echo "  No NoSchedule taints found on GPU nodes."
+    fi
+  else
+    echo "  ⚠ No NVIDIA GPUs detected. The default deployment mode (local Llama 3.2) requires 1 GPU."
+    echo "    Use MaaS mode (bring your own model endpoint) to deploy without a GPU."
+  fi
+
+  # --------------------------------------------------------------------------
+  # Report results
+  # --------------------------------------------------------------------------
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    local missing_json="["
+    for i in "${!missing[@]}"; do
+      if [[ $i -gt 0 ]]; then
+        missing_json+=","
+      fi
+      missing_json+="${missing[$i]}"
+    done
+    missing_json+="]"
+    log_prerequisites_failed "$missing_json"
+    return 2
+  fi
+
+  echo "All prerequisites satisfied."
+  return 0
+}

--- a/installer/lib/install.sh
+++ b/installer/lib/install.sh
@@ -28,6 +28,16 @@ detect_gpu_tolerations() {
   echo "$json"
 }
 
+# Append a string-typed Helm override to the helm_args array.
+# Uses --set-string so values are never coerced to bool/number, and
+# backslash-escapes literal commas that Helm would otherwise treat as
+# --set multi-value delimiters (e.g. "Red Hat, Inc.").
+append_set_string() {
+  local key="$1" value="$2"
+  value="${value//,/\\,}"
+  helm_args+=("--set-string" "${key}=${value}")
+}
+
 deploy_quickstart() {
   local ns="$TARGET_NAMESPACE"
 
@@ -47,18 +57,19 @@ deploy_quickstart() {
     "--timeout" "15m"
   )
 
-  # MaaS mode: pass model configuration if provided
+  # MaaS mode: pass model configuration if provided.
+  # name/endpoint/api_key are free text -> --set-string; port is numeric.
   if [[ -n "${MODEL_NAME:-}" ]]; then
-    helm_args+=("--set" "model.name=${MODEL_NAME}")
+    append_set_string "model.name" "$MODEL_NAME"
   fi
   if [[ -n "${MODEL_ENDPOINT:-}" ]]; then
-    helm_args+=("--set" "model.endpoint=${MODEL_ENDPOINT}")
+    append_set_string "model.endpoint" "$MODEL_ENDPOINT"
   fi
   if [[ -n "${MODEL_PORT:-}" ]]; then
     helm_args+=("--set" "model.port=${MODEL_PORT}")
   fi
   if [[ -n "${MODEL_API_KEY:-}" ]]; then
-    helm_args+=("--set" "model.api_key=${MODEL_API_KEY}")
+    append_set_string "model.api_key" "$MODEL_API_KEY"
   fi
 
   # GPU tolerations: use provided value or auto-detect from cluster

--- a/installer/lib/install.sh
+++ b/installer/lib/install.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+# ============================================================================
+# Lemonade Stand Assistant — Install
+# ============================================================================
+
+detect_gpu_tolerations() {
+  local taint_keys
+  taint_keys=$(oc get nodes -o json 2>/dev/null | \
+    jq -r '[.items[] | select(.status.allocatable["nvidia.com/gpu"] // "0" | tonumber > 0) | .spec.taints // [] | .[] | select(.effect == "NoSchedule") | .key] | unique | .[]' 2>/dev/null || echo "")
+
+  if [[ -z "$taint_keys" ]]; then
+    echo '[{"effect":"NoSchedule","key":"nvidia.com/gpu","operator":"Exists"}]'
+    return
+  fi
+
+  local json="["
+  local first=true
+  while IFS= read -r key; do
+    [[ -z "$key" ]] && continue
+    if [[ "$first" == "true" ]]; then
+      first=false
+    else
+      json+=","
+    fi
+    json+="{\"effect\":\"NoSchedule\",\"key\":\"${key}\",\"operator\":\"Exists\"}"
+  done <<< "$taint_keys"
+  json+="]"
+  echo "$json"
+}
+
+deploy_quickstart() {
+  local ns="$TARGET_NAMESPACE"
+
+  # Create namespace if it doesn't exist
+  if oc get namespace "$ns" &>/dev/null; then
+    echo "Namespace $ns already exists"
+  else
+    echo "Creating namespace $ns..."
+    oc create namespace "$ns" || true
+  fi
+
+  # Build helm install command
+  local helm_args=(
+    "install" "lemonade-stand-assistant" "/installer/chart"
+    "--namespace" "$ns"
+    "--wait"
+    "--timeout" "15m"
+  )
+
+  # MaaS mode: pass model configuration if provided
+  if [[ -n "${MODEL_NAME:-}" ]]; then
+    helm_args+=("--set" "model.name=${MODEL_NAME}")
+  fi
+  if [[ -n "${MODEL_ENDPOINT:-}" ]]; then
+    helm_args+=("--set" "model.endpoint=${MODEL_ENDPOINT}")
+  fi
+  if [[ -n "${MODEL_PORT:-}" ]]; then
+    helm_args+=("--set" "model.port=${MODEL_PORT}")
+  fi
+  if [[ -n "${MODEL_API_KEY:-}" ]]; then
+    helm_args+=("--set" "model.api_key=${MODEL_API_KEY}")
+  fi
+
+  # GPU tolerations: use provided value or auto-detect from cluster
+  local gpu_tolerations
+  if [[ -n "${GPU_TOLERATIONS:-}" ]]; then
+    gpu_tolerations="$GPU_TOLERATIONS"
+    echo "Using provided GPU tolerations: $gpu_tolerations"
+  else
+    echo "Auto-detecting GPU taint keys from cluster nodes..."
+    gpu_tolerations=$(detect_gpu_tolerations)
+    echo "Detected GPU tolerations: $gpu_tolerations"
+  fi
+
+  local idx=0
+  for row in $(echo "$gpu_tolerations" | jq -c '.[]'); do
+    local key effect operator
+    key=$(echo "$row" | jq -r '.key')
+    effect=$(echo "$row" | jq -r '.effect')
+    operator=$(echo "$row" | jq -r '.operator')
+    helm_args+=("--set" "gpuTolerations[${idx}].key=${key}")
+    helm_args+=("--set" "gpuTolerations[${idx}].effect=${effect}")
+    helm_args+=("--set" "gpuTolerations[${idx}].operator=${operator}")
+    idx=$((idx + 1))
+  done
+
+  echo "Running: helm ${helm_args[*]}"
+  helm "${helm_args[@]}"
+
+  echo "Helm install complete."
+}
+
+check_deployment_status() {
+  local ns="$TARGET_NAMESPACE"
+  local max_wait=120
+  local wait_count=0
+
+  echo "Waiting for pods to be ready in namespace $ns..."
+  while [[ $wait_count -lt $max_wait ]]; do
+    local total ready not_ready
+    total=$(oc get pods -n "$ns" --no-headers 2>/dev/null | wc -l | tr -d ' ')
+    ready=$(oc get pods -n "$ns" --no-headers 2>/dev/null | grep -c "Running\|Completed\|Succeeded" || echo "0")
+    not_ready=$((total - ready))
+
+    echo "  Pods: $ready/$total ready"
+
+    if [[ "$total" -gt 0 && "$not_ready" -eq 0 ]]; then
+      echo "All pods are ready."
+      return 0
+    fi
+
+    sleep 10
+    wait_count=$((wait_count + 1))
+  done
+
+  echo "Warning: Not all pods became ready within timeout. Continuing..."
+  return 0
+}
+
+get_endpoints() {
+  local ns="$TARGET_NAMESPACE"
+  local endpoints="[]"
+
+  local app_route
+  app_route=$(oc get route lemonade-stand -n "$ns" -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
+
+  local dashboard_route
+  dashboard_route=$(oc get route shiny-dashboard -n "$ns" -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
+
+  endpoints="["
+  local first=true
+
+  if [[ -n "$app_route" ]]; then
+    endpoints+="{\"name\":\"Lemonade Stand Chat\",\"url\":\"https://${app_route}\",\"type\":\"route\"}"
+    first=false
+  fi
+
+  if [[ -n "$dashboard_route" ]]; then
+    if [[ "$first" == "false" ]]; then
+      endpoints+=","
+    fi
+    endpoints+="{\"name\":\"Monitoring Dashboard\",\"url\":\"https://${dashboard_route}\",\"type\":\"route\"}"
+  fi
+
+  endpoints+="]"
+  echo "$endpoints"
+}

--- a/installer/lib/status.sh
+++ b/installer/lib/status.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# ============================================================================
+# Lemonade Stand Assistant — Status Check
+# ============================================================================
+
+verify_deployment() {
+  local ns="$TARGET_NAMESPACE"
+
+  # Check if namespace exists
+  if ! oc get namespace "$ns" &>/dev/null; then
+    echo "Namespace $ns does not exist. Quickstart is not deployed."
+    return 0
+  fi
+
+  local ns_phase
+  ns_phase=$(oc get namespace "$ns" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+  if [[ "$ns_phase" == "Terminating" ]]; then
+    echo "Namespace $ns is terminating."
+    return 0
+  fi
+
+  # Check Helm release
+  echo "Checking Helm release..."
+  if helm list -n "$ns" 2>/dev/null | grep -q "lemonade-stand-assistant"; then
+    local helm_status
+    helm_status=$(helm status lemonade-stand-assistant -n "$ns" -o json 2>/dev/null | jq -r '.info.status' 2>/dev/null || echo "unknown")
+    echo "  Helm release status: $helm_status"
+  else
+    echo "  No Helm release found."
+  fi
+
+  # Check pod status
+  echo "Checking pod status..."
+  local pods
+  pods=$(oc get pods -n "$ns" --no-headers 2>/dev/null || echo "")
+  if [[ -z "$pods" ]]; then
+    echo "  No pods found in namespace $ns."
+    return 0
+  fi
+
+  local total ready running failed pending
+  total=$(echo "$pods" | wc -l | tr -d ' ')
+  running=$(echo "$pods" | { grep "Running" || true; } | wc -l | tr -d ' ')
+  ready=$(echo "$pods" | { grep -E "1/1|2/2|3/3|4/4|5/5" || true; } | wc -l | tr -d ' ')
+  failed=$(echo "$pods" | { grep -E "Error|CrashLoopBackOff|ImagePullBackOff" || true; } | wc -l | tr -d ' ')
+  pending=$(echo "$pods" | { grep -E "Pending|ContainerCreating|Init:" || true; } | wc -l | tr -d ' ')
+
+  echo "  Total pods: $total"
+  echo "  Running: $running"
+  echo "  Ready: $ready"
+  echo "  Failed: $failed"
+  echo "  Pending: $pending"
+
+  # List pods with issues
+  if [[ "${failed:-0}" -gt 0 ]]; then
+    echo "  Pods with issues:"
+    echo "$pods" | { grep "Error\|CrashLoopBackOff\|ImagePullBackOff" || true; } | while read -r line; do
+      echo "    $line"
+    done
+  fi
+
+  # Check InferenceService status
+  echo "Checking InferenceServices..."
+  local isvc_list
+  isvc_list=$(oc get inferenceservices -n "$ns" --no-headers 2>/dev/null || echo "")
+  if [[ -n "$isvc_list" ]]; then
+    echo "$isvc_list" | while read -r line; do
+      echo "  $line"
+    done
+  else
+    echo "  No InferenceServices found."
+  fi
+
+  # Check routes
+  echo "Checking routes..."
+  local app_route
+  app_route=$(oc get route lemonade-stand -n "$ns" -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
+  if [[ -n "$app_route" ]]; then
+    echo "  ✓ Lemonade Stand Chat: https://$app_route"
+  else
+    echo "  ✗ Lemonade Stand Chat route not found"
+  fi
+
+  local dashboard_route
+  dashboard_route=$(oc get route shiny-dashboard -n "$ns" -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
+  if [[ -n "$dashboard_route" ]]; then
+    echo "  ✓ Monitoring Dashboard: https://$dashboard_route"
+  else
+    echo "  ✗ Monitoring Dashboard route not found"
+  fi
+
+  # Check health endpoint
+  if [[ -n "$app_route" ]]; then
+    echo "Checking health endpoint..."
+    local health_status
+    health_status=$(curl -sk -o /dev/null -w "%{http_code}" "https://${app_route}/health" 2>/dev/null || echo "000")
+    if [[ "$health_status" == "200" ]]; then
+      echo "  ✓ Health endpoint: OK (HTTP $health_status)"
+    else
+      echo "  ⚠ Health endpoint: HTTP $health_status"
+    fi
+  fi
+
+  echo "Status check complete."
+}

--- a/installer/lib/uninstall.sh
+++ b/installer/lib/uninstall.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# ============================================================================
+# Lemonade Stand Assistant — Uninstall
+# ============================================================================
+
+cleanup_quickstart() {
+  local mode=$1
+  local ns="$TARGET_NAMESPACE"
+
+  # Check if namespace exists
+  if ! oc get namespace "$ns" &>/dev/null; then
+    echo "Namespace $ns does not exist. Nothing to uninstall."
+    return 0
+  fi
+
+  # Uninstall Helm release if it exists
+  if helm list -n "$ns" 2>/dev/null | grep -q "lemonade-stand-assistant"; then
+    echo "Uninstalling Helm release lemonade-stand-assistant..."
+    helm uninstall lemonade-stand-assistant --namespace "$ns" --wait --timeout 5m || true
+    echo "Helm release uninstalled."
+  else
+    echo "No Helm release found. Cleaning up remaining resources..."
+  fi
+
+  case "$mode" in
+    delete-all)
+      echo "Deleting all resources including data volumes..."
+
+      # Delete any remaining resources not managed by Helm
+      oc delete inferenceservices --all -n "$ns" --ignore-not-found=true 2>/dev/null || true
+      oc delete servingruntimes --all -n "$ns" --ignore-not-found=true 2>/dev/null || true
+      oc delete guardrailsorchestrators --all -n "$ns" --ignore-not-found=true 2>/dev/null || true
+      oc delete servicemonitors --all -n "$ns" --ignore-not-found=true 2>/dev/null || true
+
+      # Delete PVCs
+      echo "Deleting persistent volume claims..."
+      oc delete pvc --all -n "$ns" --ignore-not-found=true 2>/dev/null || true
+
+      # Delete the namespace
+      echo "Deleting namespace $ns..."
+      oc delete namespace "$ns" --ignore-not-found=true 2>/dev/null || true
+
+      # Wait for namespace deletion
+      local wait_count=0
+      while [[ $wait_count -lt 60 ]]; do
+        local ns_phase
+        ns_phase=$(oc get namespace "$ns" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+        if [[ -z "$ns_phase" ]]; then
+          echo "Namespace $ns deleted."
+          break
+        fi
+        if [[ "$ns_phase" == "Terminating" ]]; then
+          echo "  Namespace $ns is terminating..."
+        fi
+        sleep 5
+        wait_count=$((wait_count + 1))
+      done
+      ;;
+
+    keep-data)
+      echo "Removing workloads but preserving data volumes..."
+
+      # Delete workloads and services but keep PVCs
+      oc delete deployments --all -n "$ns" --ignore-not-found=true 2>/dev/null || true
+      oc delete services --all -n "$ns" --ignore-not-found=true 2>/dev/null || true
+      oc delete routes --all -n "$ns" --ignore-not-found=true 2>/dev/null || true
+      oc delete configmaps --all -n "$ns" --ignore-not-found=true 2>/dev/null || true
+      oc delete secrets --all -n "$ns" --ignore-not-found=true 2>/dev/null || true
+      oc delete jobs --all -n "$ns" --ignore-not-found=true 2>/dev/null || true
+      oc delete inferenceservices --all -n "$ns" --ignore-not-found=true 2>/dev/null || true
+      oc delete servingruntimes --all -n "$ns" --ignore-not-found=true 2>/dev/null || true
+      oc delete guardrailsorchestrators --all -n "$ns" --ignore-not-found=true 2>/dev/null || true
+      oc delete servicemonitors --all -n "$ns" --ignore-not-found=true 2>/dev/null || true
+
+      echo "Workloads removed. PVCs preserved in namespace $ns."
+      ;;
+  esac
+
+  echo "Uninstall complete."
+}

--- a/installer/lib/upgrade.sh
+++ b/installer/lib/upgrade.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# ============================================================================
+# Lemonade Stand Assistant — Upgrade (not supported)
+# ============================================================================
+# Stub file. UPGRADE action is rejected by entrypoint.sh before reaching here.

--- a/quickstart-manifest.schema.json
+++ b/quickstart-manifest.schema.json
@@ -1,0 +1,901 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://quickstart.redhat.com/schemas/quickstart-manifest-v1.json",
+  "title": "Quickstart Manifest",
+  "description": "Machine-readable metadata for integrating quickstart deployment with the OpenShift Project Navigator. Enables chat-driven and catalog UI discovery, evaluation, and deployment.",
+  "type": "object",
+  "required": ["apiVersion", "kind", "metadata"],
+  "additionalProperties": false,
+  "properties": {
+    "apiVersion": {
+      "type": "string",
+      "enum": ["quickstart.redhat.com/v1"],
+      "description": "Manifest schema version. Indicates the format/structure of this manifest file. Navigator uses this to determine how to parse the manifest."
+    },
+    "kind": {
+      "type": "string",
+      "enum": ["Quickstart"],
+      "description": "Resource kind identifier."
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Quickstart-specific metadata for identification and display.",
+      "required": ["name", "displayName", "shortDescription", "version"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$",
+          "description": "Unique identifier (DNS-compatible). Used as a stable key across Navigator operations."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Human-readable display name shown in catalog and UI."
+        },
+        "shortDescription": {
+          "type": "string",
+          "maxLength": 160,
+          "description": "Short description (< 160 chars) for catalog tile display."
+        },
+        "longDescription": {
+          "type": "string",
+          "description": "Detailed description for the full quickstart view. Supports multi-line text."
+        },
+        "version": {
+          "type": "string",
+          "pattern": "^\\d+\\.\\d+\\.\\d+",
+          "description": "Semantic version of this quickstart release. Referenced throughout the manifest (upgrade paths, installer image tag, etc.)."
+        },
+        "repository": {
+          "type": "string",
+          "format": "uri",
+          "description": "Source repository URL for quickstart-specific deployment configs."
+        },
+        "maintainer": {
+          "$ref": "#/$defs/maintainer"
+        },
+        "license": {
+          "type": "string",
+          "description": "SPDX license identifier (e.g., Apache-2.0, MIT)."
+        },
+        "lastUpdated": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp of the last manifest update."
+        }
+      }
+    },
+    "versioning": {
+      "type": "object",
+      "description": "Version management and upgrade support. Navigator uses this to determine if in-place upgrades are possible.",
+      "additionalProperties": false,
+      "properties": {
+        "upgradePaths": {
+          "type": "array",
+          "description": "Supported upgrade paths from older versions. All upgrade paths must have 'to' matching metadata.version.",
+          "items": {
+            "$ref": "#/$defs/upgradePath"
+          }
+        },
+        "installerImageTag": {
+          "type": "string",
+          "description": "Installer image tag that must match metadata.version. Ensures the installer has the correct upgrade logic for this version."
+        }
+      }
+    },
+    "classification": {
+      "type": "object",
+      "description": "Classification and discovery metadata for catalog search and filtering.",
+      "additionalProperties": false,
+      "properties": {
+        "industries": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Industry verticals this quickstart serves."
+        },
+        "useCases": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Business use cases addressed by this quickstart."
+        },
+        "aiCapabilities": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "AI/ML capabilities demonstrated by this quickstart."
+        },
+        "technologies": {
+          "type": "array",
+          "description": "Technologies featured in this quickstart.",
+          "items": {
+            "$ref": "#/$defs/technology"
+          }
+        },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Searchable tags for catalog discovery."
+        },
+        "estimatedDeploymentTime": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Estimated time to deploy in minutes."
+        }
+      }
+    },
+    "prerequisites": {
+      "type": "object",
+      "description": "What must exist before deployment can begin.",
+      "additionalProperties": false,
+      "properties": {
+        "openshift": {
+          "type": "object",
+          "description": "OpenShift version requirements.",
+          "additionalProperties": false,
+          "properties": {
+            "minimumVersion": {
+              "type": "string",
+              "description": "Minimum supported OpenShift version."
+            },
+            "tested": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "OpenShift versions this quickstart has been tested against."
+            }
+          }
+        },
+        "operators": {
+          "type": "array",
+          "description": "Required or optional operators.",
+          "items": {
+            "$ref": "#/$defs/operatorRequirement"
+          }
+        },
+        "resources": {
+          "type": "object",
+          "description": "Cluster resource requirements.",
+          "additionalProperties": false,
+          "properties": {
+            "minimum": {
+              "$ref": "#/$defs/resourceRequirement",
+              "description": "Minimum resources required (e.g., CPU-only mode)."
+            },
+            "recommended": {
+              "$ref": "#/$defs/resourceRequirement",
+              "description": "Recommended resources for optimal performance (e.g., with GPU)."
+            }
+          }
+        },
+        "storageClasses": {
+          "type": "array",
+          "description": "Storage classes needed for persistent volumes.",
+          "items": {
+            "$ref": "#/$defs/storageClassRequirement"
+          }
+        },
+        "externalServices": {
+          "type": "array",
+          "description": "External service dependencies (optional or required).",
+          "items": {
+            "$ref": "#/$defs/externalService"
+          }
+        }
+      }
+    },
+    "deployment": {
+      "type": "object",
+      "description": "Deployment configuration used by Navigator to run the installer.",
+      "additionalProperties": false,
+      "properties": {
+        "supportedActions": {
+          "type": "array",
+          "description": "Deployment actions this quickstart supports. Navigator uses this to determine which actions to expose to users.",
+          "items": {
+            "type": "string",
+            "enum": ["CHECK_PRE_REQS", "STATUS", "INSTALL", "UNINSTALL_DELETE_ALL", "UNINSTALL_KEEP_DATA", "UPGRADE"]
+          }
+        },
+        "supportedModes": {
+          "type": "array",
+          "description": "Installation modes this quickstart supports. Navigator uses this to validate the INSTALL_MODE parameter.",
+          "items": {
+            "type": "string",
+            "enum": ["DEMO", "PRODUCTION"]
+          }
+        },
+        "installer": {
+          "type": "object",
+          "description": "Installer container image configuration.",
+          "required": ["image"],
+          "additionalProperties": false,
+          "properties": {
+            "image": {
+              "type": "string",
+              "description": "Full container image reference (registry/name:tag)."
+            },
+            "command": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Container entrypoint command override."
+            },
+            "requiredEnv": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Environment variables the installer expects to be set."
+            },
+            "rbac": {
+              "$ref": "#/$defs/installerRbac"
+            }
+          }
+        },
+        "defaultNamespace": {
+          "type": "string",
+          "description": "Default target namespace for deployment (can be overridden by user)."
+        },
+        "quickstartResources": {
+          "type": "object",
+          "description": "Resources deployed by the quickstart (for catalog display and dependency checking). Separate from installer RBAC.",
+          "additionalProperties": false,
+          "properties": {
+            "namespaceScoped": {
+              "type": "array",
+              "description": "Namespace-scoped resources created by the quickstart.",
+              "items": {
+                "$ref": "#/$defs/resourceDescription"
+              }
+            },
+            "clusterScoped": {
+              "type": "array",
+              "description": "Cluster-scoped resources created by the quickstart.",
+              "items": {
+                "$ref": "#/$defs/resourceDescription"
+              }
+            }
+          }
+        }
+      }
+    },
+    "parameters": {
+      "type": "object",
+      "description": "Configuration parameters that the user can set before or during deployment.",
+      "additionalProperties": false,
+      "properties": {
+        "secrets": {
+          "type": "array",
+          "description": "Secrets that must be generated or provided by the user.",
+          "items": {
+            "$ref": "#/$defs/parameter"
+          }
+        },
+        "configuration": {
+          "type": "array",
+          "description": "Configuration options for customizing the deployment.",
+          "items": {
+            "$ref": "#/$defs/parameter"
+          }
+        }
+      }
+    },
+    "status": {
+      "type": "object",
+      "description": "Status reporting configuration. Navigator uses this to poll quickstart health.",
+      "additionalProperties": false,
+      "properties": {
+        "endpoint": {
+          "type": "object",
+          "description": "Status API endpoint that Navigator polls.",
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "type": "string",
+              "description": "URL path for the status endpoint."
+            },
+            "description": {
+              "type": "string",
+              "description": "Human-readable description of what the endpoint returns."
+            }
+          }
+        },
+        "responseFormat": {
+          "type": "object",
+          "description": "Expected response format from the status endpoint.",
+          "additionalProperties": false,
+          "properties": {
+            "schema": {
+              "type": "object",
+              "description": "JSON Schema describing the status response structure."
+            },
+            "example": {
+              "type": "object",
+              "description": "Example responses keyed by status value.",
+              "additionalProperties": { "type": "string" }
+            }
+          }
+        },
+        "pollingInterval": {
+          "type": "string",
+          "pattern": "^\\d+[smh]$",
+          "description": "How often Navigator checks status during deployment/upgrade (e.g., '10s', '1m')."
+        },
+        "timeout": {
+          "type": "string",
+          "pattern": "^\\d+[smh]$",
+          "description": "Maximum time to wait for status to become READY (e.g., '15m', '1h')."
+        }
+      }
+    },
+    "access": {
+      "type": "object",
+      "description": "Access information for the deployed application.",
+      "additionalProperties": false,
+      "properties": {
+        "endpoints": {
+          "type": "array",
+          "description": "How users access the deployed application.",
+          "items": {
+            "$ref": "#/$defs/accessEndpoint"
+          }
+        },
+        "defaultCredentials": {
+          "type": "array",
+          "description": "Default credentials for accessing the application.",
+          "items": {
+            "$ref": "#/$defs/credential"
+          }
+        }
+      }
+    },
+    "cleanup": {
+      "type": "object",
+      "description": "Cleanup and uninstallation information.",
+      "additionalProperties": false,
+      "properties": {
+        "dataDescription": {
+          "type": "string",
+          "description": "User-facing description of what data the quickstart stores."
+        },
+        "warning": {
+          "type": "string",
+          "description": "Warning shown before uninstallation explaining the consequences."
+        }
+      }
+    },
+    "documentation": {
+      "type": "object",
+      "description": "Links to user-facing documentation.",
+      "additionalProperties": {
+        "type": "string",
+        "format": "uri"
+      },
+      "properties": {
+        "readme": {
+          "type": "string",
+          "format": "uri",
+          "description": "Link to the main README."
+        },
+        "installGuide": {
+          "type": "string",
+          "format": "uri",
+          "description": "Link to the installation guide."
+        }
+      }
+    },
+    "llmContext": {
+      "type": "object",
+      "description": "Metadata for LLM prompting. Provides natural language hints for the Navigator chat interface.",
+      "additionalProperties": false,
+      "properties": {
+        "whenToRecommend": {
+          "type": "string",
+          "description": "Natural language guidance for when the Navigator should recommend this quickstart."
+        },
+        "faq": {
+          "type": "array",
+          "description": "Common questions users might ask about this quickstart.",
+          "items": {
+            "$ref": "#/$defs/faqItem"
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "maintainer": {
+      "type": "object",
+      "description": "Maintainer contact information.",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Maintainer name or team name."
+        },
+        "email": {
+          "type": "string",
+          "format": "email",
+          "description": "Maintainer contact email."
+        }
+      }
+    },
+    "upgradePath": {
+      "type": "object",
+      "description": "Defines a supported upgrade path from one version to another.",
+      "required": ["from", "to"],
+      "additionalProperties": false,
+      "properties": {
+        "from": {
+          "type": "string",
+          "description": "Source version to upgrade from."
+        },
+        "to": {
+          "type": "string",
+          "description": "Target version to upgrade to. Must match metadata.version."
+        },
+        "notes": {
+          "type": "string",
+          "description": "User-facing upgrade notes. Navigator shows this before upgrade."
+        },
+        "estimatedTime": {
+          "type": "string",
+          "pattern": "^\\d+[smh]$",
+          "description": "Estimated upgrade duration (e.g., '20m', '1h')."
+        },
+        "reversible": {
+          "type": "boolean",
+          "description": "Whether this upgrade can be rolled back."
+        },
+        "requiresDataBackup": {
+          "type": "boolean",
+          "description": "Whether the user should back up data before upgrading."
+        },
+        "requiresDataMigration": {
+          "type": "boolean",
+          "description": "Whether database/data will be modified during upgrade."
+        },
+        "requiresManualSteps": {
+          "type": "boolean",
+          "description": "Whether manual intervention is needed beyond approval."
+        }
+      }
+    },
+    "technology": {
+      "type": "object",
+      "description": "A technology featured in the quickstart.",
+      "required": ["name", "role"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Technology name."
+        },
+        "role": {
+          "type": "string",
+          "description": "What role this technology plays in the quickstart."
+        },
+        "partner": {
+          "type": "string",
+          "description": "Partner or organization behind this technology."
+        }
+      }
+    },
+    "operatorRequirement": {
+      "type": "object",
+      "description": "An operator required or optional for the quickstart.",
+      "required": ["name", "required"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Operator display name."
+        },
+        "namespace": {
+          "type": "string",
+          "enum": ["target", "cluster"],
+          "description": "'target' means same namespace as quickstart, 'cluster' means cluster-wide."
+        },
+        "minimumVersion": {
+          "type": "string",
+          "description": "Minimum required operator version."
+        },
+        "required": {
+          "type": "boolean",
+          "description": "Whether this operator is required (true) or optional (false)."
+        },
+        "autoInstalled": {
+          "type": "boolean",
+          "description": "Whether the quickstart installer automatically installs this operator."
+        },
+        "installationHint": {
+          "type": "string",
+          "description": "User-facing hint about how to install this operator or what it provides."
+        }
+      }
+    },
+    "resourceRequirement": {
+      "type": "object",
+      "description": "Cluster resource requirements.",
+      "additionalProperties": false,
+      "properties": {
+        "cpu": {
+          "type": "string",
+          "description": "CPU requirement (e.g., '4', '8')."
+        },
+        "memory": {
+          "type": "string",
+          "description": "Memory requirement (e.g., '16Gi', '32Gi')."
+        },
+        "storage": {
+          "type": "string",
+          "description": "Storage requirement (e.g., '100Gi', '150Gi')."
+        },
+        "gpu": {
+          "type": "object",
+          "description": "GPU requirements (if applicable).",
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Number of GPUs required."
+            },
+            "memory": {
+              "type": "string",
+              "description": "GPU memory required (e.g., '16Gi')."
+            }
+          }
+        }
+      }
+    },
+    "storageClassRequirement": {
+      "type": "object",
+      "description": "A storage class required for persistent volumes.",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Storage class name. Use 'any-rwo' to indicate any ReadWriteOnce class."
+        },
+        "accessModes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["ReadWriteOnce", "ReadWriteMany", "ReadOnlyMany"]
+          },
+          "description": "Required access modes."
+        },
+        "minimumSize": {
+          "type": "string",
+          "description": "Minimum volume size (e.g., '10Gi')."
+        },
+        "usage": {
+          "type": "string",
+          "description": "What this storage is used for."
+        }
+      }
+    },
+    "externalService": {
+      "type": "object",
+      "description": "An external service dependency.",
+      "required": ["name", "required"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Service name."
+        },
+        "required": {
+          "type": "boolean",
+          "description": "Whether this service is required (true) or optional (false)."
+        },
+        "purpose": {
+          "type": "string",
+          "description": "What this service is used for."
+        },
+        "configurationHint": {
+          "type": "string",
+          "description": "User-facing hint about how to configure this service."
+        }
+      }
+    },
+    "rbacRule": {
+      "type": "object",
+      "description": "A Kubernetes RBAC rule.",
+      "required": ["apiGroups", "resources", "verbs"],
+      "additionalProperties": false,
+      "properties": {
+        "apiGroups": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "API groups (empty string for core group)."
+        },
+        "resources": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Resource types."
+        },
+        "verbs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["get", "list", "watch", "create", "update", "patch", "delete"]
+          },
+          "description": "Allowed operations."
+        }
+      }
+    },
+    "installerRbac": {
+      "type": "object",
+      "description": "RBAC requirements for the installer Job. Navigator creates these resources before running the Job and cleans them up after completion.",
+      "additionalProperties": false,
+      "properties": {
+        "serviceAccount": {
+          "type": "object",
+          "description": "ServiceAccount for the installer Job.",
+          "required": ["name", "namespace"],
+          "additionalProperties": false,
+          "properties": {
+            "name": { "type": "string" },
+            "namespace": { "type": "string" }
+          }
+        },
+        "defaultNamespaceRole": {
+          "type": "object",
+          "description": "Role in the default namespace for the installer pod to inspect its own environment.",
+          "required": ["name", "namespace", "rules"],
+          "additionalProperties": false,
+          "properties": {
+            "name": { "type": "string" },
+            "namespace": { "type": "string" },
+            "rules": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/rbacRule" }
+            }
+          }
+        },
+        "defaultNamespaceRoleBinding": {
+          "type": "object",
+          "description": "RoleBinding in the default namespace.",
+          "required": ["name", "namespace", "roleRef", "subjects"],
+          "additionalProperties": false,
+          "properties": {
+            "name": { "type": "string" },
+            "namespace": { "type": "string" },
+            "roleRef": {
+              "$ref": "#/$defs/rbacRef"
+            },
+            "subjects": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/rbacSubject" }
+            }
+          }
+        },
+        "clusterRole": {
+          "type": "object",
+          "description": "ClusterRole with all installation permissions. When bound via ClusterRoleBinding, namespace-scoped permissions apply to ALL namespaces.",
+          "required": ["name", "rules"],
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "ClusterRole name. May contain ${TARGET_NAMESPACE} which Navigator substitutes."
+            },
+            "rules": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/rbacRule" }
+            }
+          }
+        },
+        "clusterRoleBinding": {
+          "type": "object",
+          "description": "ClusterRoleBinding that binds the ClusterRole to the ServiceAccount.",
+          "required": ["name", "roleRef", "subjects"],
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "ClusterRoleBinding name. May contain ${TARGET_NAMESPACE} which Navigator substitutes."
+            },
+            "roleRef": {
+              "$ref": "#/$defs/rbacRef"
+            },
+            "subjects": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/rbacSubject" }
+            }
+          }
+        }
+      }
+    },
+    "rbacRef": {
+      "type": "object",
+      "description": "Reference to a Role or ClusterRole.",
+      "required": ["kind", "name"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["Role", "ClusterRole"],
+          "description": "Kind of the referenced role."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the referenced role. May contain ${TARGET_NAMESPACE}."
+        }
+      }
+    },
+    "rbacSubject": {
+      "type": "object",
+      "description": "RBAC subject (ServiceAccount, User, or Group).",
+      "required": ["kind", "name"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["ServiceAccount", "User", "Group"],
+          "description": "Subject kind."
+        },
+        "name": {
+          "type": "string",
+          "description": "Subject name."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Subject namespace (required for ServiceAccount)."
+        }
+      }
+    },
+    "resourceDescription": {
+      "type": "object",
+      "description": "Description of Kubernetes resources deployed by the quickstart.",
+      "required": ["apiGroups", "resources"],
+      "additionalProperties": false,
+      "properties": {
+        "apiGroups": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "API groups."
+        },
+        "resources": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Resource types."
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of these resources."
+        }
+      }
+    },
+    "parameter": {
+      "type": "object",
+      "description": "A configurable parameter for the quickstart.",
+      "required": ["name", "displayName", "type"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Parameter identifier (dot-notation, e.g., 'ollama.gpu.enabled')."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Human-readable parameter name."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of what this parameter controls."
+        },
+        "type": {
+          "type": "string",
+          "enum": ["string", "boolean", "integer", "password"],
+          "description": "Parameter data type."
+        },
+        "required": {
+          "type": "boolean",
+          "description": "Whether this parameter must be provided."
+        },
+        "default": {
+          "description": "Default value if not provided by the user."
+        },
+        "llmGuidance": {
+          "type": "string",
+          "description": "Natural language guidance for the Navigator LLM on how to handle this parameter."
+        }
+      }
+    },
+    "accessEndpoint": {
+      "type": "object",
+      "description": "An application endpoint users can access.",
+      "required": ["name", "displayName", "type"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Endpoint identifier."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Human-readable endpoint name."
+        },
+        "type": {
+          "type": "string",
+          "enum": ["route", "service", "ingress"],
+          "description": "How the endpoint is exposed."
+        },
+        "path": {
+          "type": "string",
+          "description": "URL path for this endpoint."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of what this endpoint provides."
+        },
+        "public": {
+          "type": "boolean",
+          "description": "Whether this endpoint is publicly accessible."
+        },
+        "authentication": {
+          "type": "string",
+          "enum": ["none", "required", "admin"],
+          "description": "Authentication level required to access this endpoint."
+        },
+        "credentialsSecret": {
+          "type": "string",
+          "description": "Name of the Kubernetes secret containing credentials for this endpoint."
+        }
+      }
+    },
+    "credential": {
+      "type": "object",
+      "description": "Default credentials for accessing the application.",
+      "required": ["name", "username"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Human-readable credential name."
+        },
+        "username": {
+          "type": "string",
+          "description": "Username or email for login."
+        },
+        "passwordParameter": {
+          "type": "string",
+          "description": "Reference to a parameter name that holds the password."
+        },
+        "passwordSecret": {
+          "type": "string",
+          "description": "Name of the Kubernetes secret containing the password."
+        },
+        "passwordKey": {
+          "type": "string",
+          "description": "Key within the secret that holds the password."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of this credential and its purpose."
+        },
+        "roles": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Roles assigned to this credential."
+        }
+      }
+    },
+    "faqItem": {
+      "type": "object",
+      "description": "A frequently asked question about the quickstart.",
+      "required": ["question", "answer"],
+      "additionalProperties": false,
+      "properties": {
+        "question": {
+          "type": "string",
+          "description": "The question."
+        },
+        "answer": {
+          "type": "string",
+          "description": "The answer."
+        }
+      }
+    }
+  }
+}

--- a/quickstart-manifest.yaml
+++ b/quickstart-manifest.yaml
@@ -1,0 +1,349 @@
+# yaml-language-server: $schema=quickstart-manifest.schema.json
+
+apiVersion: quickstart.redhat.com/v1
+kind: Quickstart
+
+metadata:
+  name: lemonade-stand-assistant
+  displayName: "Lemonade Stand Assistant"
+  shortDescription: "Deploy an AI-powered customer service assistant with built-in safety guardrails to ensure family-friendly, compliant interactions for your business."
+  longDescription: |
+    Imagine we run a successful lemonade stand and want to deploy a customer service agent so our
+    customers can learn more about our products. We'll want to make sure all conversations with the
+    agent are family friendly, and that it does not promote our rival fruit juice vendors.
+
+    This demo showcases how to deploy an AI-powered customer service assistant with multiple guardrails
+    to ensure safe, compliant, and on-brand interactions. The solution uses Llama 3.2 as the default
+    language model (or your own model endpoint), protected by three detector models that monitor for
+    harmful content, prompt injection attacks, and language compliance.
+  version: "1.0.0"
+  repository: "https://github.com/rh-ai-quickstart/lemonade-stand-assistant"
+  maintainer:
+    name: "Red Hat AI Quickstart Team"
+  license: "MIT"
+  lastUpdated: "2026-07-28T00:00:00Z"
+
+classification:
+  industries:
+    - "Retail"
+  useCases:
+    - "AI Safety"
+    - "Content Moderation"
+  aiCapabilities:
+    - "OpenShift AI"
+    - "TrustyAI"
+  technologies:
+    - name: "Helm"
+      role: "Deployment and packaging"
+    - name: "FastAPI"
+      role: "Chat application backend"
+    - name: "KServe"
+      role: "Model serving infrastructure"
+    - name: "vLLM"
+      role: "LLM inference runtime"
+    - name: "MinIO"
+      role: "Object storage for detector models"
+    - name: "R Shiny"
+      role: "Real-time monitoring dashboard"
+    - name: "Python"
+      role: "Application programming language"
+    - name: "IBM HAP Detector (Granite Guardian HAP 125M)"
+      role: "Harmful content detection"
+      partner: "IBM"
+    - name: "DeBERTa v3 Base Prompt Injection Detector"
+      role: "Prompt injection attack detection"
+      partner: "Protect AI"
+    - name: "Lingua Language Detector"
+      role: "Language identification"
+  tags:
+    - "ai-safety"
+    - "guardrails"
+    - "trustyai"
+    - "openshift-ai"
+    - "kserve"
+    - "llm"
+    - "retail"
+    - "customer-service"
+  estimatedDeploymentTime: 20
+
+prerequisites:
+  openshift:
+    minimumVersion: "4.21.16"
+    tested:
+      - "4.21.16"
+  operators:
+    - name: "Red Hat OpenShift AI"
+      namespace: "cluster"
+      required: true
+      autoInstalled: false
+      installationHint: "Must be installed cluster-wide before deploying. Provides KServe ServingRuntime and InferenceService CRDs."
+    - name: "TrustyAI"
+      namespace: "cluster"
+      required: true
+      autoInstalled: false
+      installationHint: "Must be enabled within Red Hat OpenShift AI. Provides the GuardrailsOrchestrator CRD."
+    - name: "Prometheus / Cluster Monitoring"
+      namespace: "cluster"
+      required: false
+      autoInstalled: false
+      installationHint: "Optional. Provides ServiceMonitor CRD for metrics collection in OpenShift console. The quickstart works without it."
+  resources:
+    minimum:
+      cpu: "9"
+      memory: "33Gi"
+      storage: "50Gi"
+      gpu:
+        count: 1
+    recommended:
+      cpu: "21"
+      memory: "60Gi"
+      storage: "50Gi"
+      gpu:
+        count: 1
+  storageClasses:
+    - name: "any-rwo"
+      accessModes:
+        - "ReadWriteOnce"
+      minimumSize: "50Gi"
+      usage: "MinIO object storage for detector model weights"
+  externalServices:
+    - name: "Huggingface"
+      required: true
+      purpose: "Download detector models (ibm-granite/granite-guardian-hap-125m, protectai/deberta-v3-base-prompt-injection-v2) at deploy time"
+      configurationHint: "Cluster must have outbound internet access to huggingface.co during installation"
+    - name: "Quay.io"
+      required: true
+      purpose: "Pull all container images including the Llama 3.2 model as an OCI artifact"
+      configurationHint: "Cluster must have outbound internet access to quay.io"
+    - name: "External LLM Endpoint"
+      required: false
+      purpose: "OpenAI-compatible API endpoint for BYO model mode (avoids GPU requirement)"
+      configurationHint: "Provide model name, endpoint hostname, port, and API key via Helm values"
+
+deployment:
+  supportedActions:
+    - "CHECK_PRE_REQS"
+    - "STATUS"
+    - "INSTALL"
+    - "UNINSTALL_DELETE_ALL"
+    - "UNINSTALL_KEEP_DATA"
+  supportedModes:
+    - "DEMO"
+  installer:
+    image: "quay.io/rh-ai-quickstart/lemonade-stand-assistant-installer:1.0.0"
+    command: ["/installer/entrypoint.sh"]
+    requiredEnv:
+      - "TARGET_NAMESPACE"
+      - "ACTION"
+      - "INSTALL_MODE"
+    rbac:
+      serviceAccount:
+        name: "lemonade-stand-assistant-installer"
+        namespace: "default"
+      defaultNamespaceRole:
+        name: "lemonade-stand-assistant-installer"
+        namespace: "default"
+        rules:
+          - apiGroups: [""]
+            resources: ["pods", "configmaps"]
+            verbs: ["get", "list", "watch"]
+          - apiGroups: ["batch"]
+            resources: ["jobs"]
+            verbs: ["get", "list", "watch"]
+      defaultNamespaceRoleBinding:
+        name: "lemonade-stand-assistant-installer"
+        namespace: "default"
+        roleRef:
+          kind: "Role"
+          name: "lemonade-stand-assistant-installer"
+        subjects:
+          - kind: "ServiceAccount"
+            name: "lemonade-stand-assistant-installer"
+            namespace: "default"
+      clusterRole:
+        name: "lemonade-stand-assistant-installer-${TARGET_NAMESPACE}"
+        rules:
+          # Cluster-scoped read permissions
+          - apiGroups: [""]
+            resources: ["nodes"]
+            verbs: ["get", "list"]
+          - apiGroups: ["storage.k8s.io"]
+            resources: ["storageclasses"]
+            verbs: ["get", "list"]
+          - apiGroups: ["config.openshift.io"]
+            resources: ["clusterversions"]
+            verbs: ["get", "list"]
+          - apiGroups: ["apiextensions.k8s.io"]
+            resources: ["customresourcedefinitions"]
+            verbs: ["get", "list"]
+          - apiGroups: ["packages.operators.coreos.com"]
+            resources: ["packagemanifests"]
+            verbs: ["get", "list"]
+          # Namespace management
+          - apiGroups: [""]
+            resources: ["namespaces"]
+            verbs: ["get", "list", "create", "delete"]
+          # Core resources
+          - apiGroups: [""]
+            resources: ["pods", "services", "secrets", "configmaps", "persistentvolumeclaims", "serviceaccounts"]
+            verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+          # Workloads
+          - apiGroups: ["apps"]
+            resources: ["deployments", "replicasets", "statefulsets"]
+            verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+          # Jobs
+          - apiGroups: ["batch"]
+            resources: ["jobs"]
+            verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+          # Routes
+          - apiGroups: ["route.openshift.io"]
+            resources: ["routes"]
+            verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+          # RBAC
+          - apiGroups: ["rbac.authorization.k8s.io"]
+            resources: ["roles", "rolebindings"]
+            verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+          # Monitoring
+          - apiGroups: ["monitoring.coreos.com"]
+            resources: ["servicemonitors"]
+            verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+          # KServe
+          - apiGroups: ["serving.kserve.io"]
+            resources: ["servingruntimes", "inferenceservices"]
+            verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+          # TrustyAI
+          - apiGroups: ["trustyai.opendatahub.io"]
+            resources: ["guardrailsorchestrators"]
+            verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+      clusterRoleBinding:
+        name: "lemonade-stand-assistant-installer-${TARGET_NAMESPACE}"
+        roleRef:
+          kind: "ClusterRole"
+          name: "lemonade-stand-assistant-installer-${TARGET_NAMESPACE}"
+        subjects:
+          - kind: "ServiceAccount"
+            name: "lemonade-stand-assistant-installer"
+            namespace: "default"
+  defaultNamespace: "lemonade-stand-assistant"
+  quickstartResources:
+    namespaceScoped:
+      - apiGroups: [""]
+        resources: ["pods", "services", "secrets", "configmaps", "persistentvolumeclaims", "serviceaccounts"]
+        description: "Core application resources (FastAPI app, MinIO, detectors)"
+      - apiGroups: ["apps"]
+        resources: ["deployments", "replicasets", "statefulsets"]
+        description: "Application workloads (chat app, detectors, dashboard, MinIO)"
+      - apiGroups: ["route.openshift.io"]
+        resources: ["routes"]
+        description: "Application ingress (chat UI, Shiny dashboard)"
+      - apiGroups: ["serving.kserve.io"]
+        resources: ["servingruntimes", "inferenceservices"]
+        description: "KServe model serving (LLM, HAP detector, prompt injection detector)"
+      - apiGroups: ["trustyai.opendatahub.io"]
+        resources: ["guardrailsorchestrators"]
+        description: "TrustyAI guardrails orchestrator"
+      - apiGroups: ["monitoring.coreos.com"]
+        resources: ["servicemonitors"]
+        description: "Prometheus metrics collection (optional)"
+
+parameters:
+  secrets:
+    - name: "model.api_key"
+      displayName: "Model API Key"
+      description: "API key for authenticating with the external model endpoint (MaaS mode only)"
+      type: "password"
+      required: false
+      llmGuidance: "Only required in MaaS/BYO model mode. API key for authenticating with the external model endpoint. Only ask for this when the user wants to bring their own model. Treat as sensitive — do not log or display."
+  configuration:
+    - name: "model.name"
+      displayName: "Model Name"
+      description: "Name of the external model to use (e.g., 'gpt-4', 'llama-3.1-70b')"
+      type: "string"
+      required: false
+      llmGuidance: "Only set this when the user wants to bring their own model (MaaS mode). This is the model name as recognized by the external endpoint. If not set, the quickstart deploys Llama 3.2 3B locally."
+    - name: "model.endpoint"
+      displayName: "Model Endpoint"
+      description: "Hostname of the external OpenAI-compatible API endpoint"
+      type: "string"
+      required: false
+      llmGuidance: "Required when model.name is set. This is the hostname of an OpenAI-compatible API endpoint. Do not include the protocol or path — just the hostname (e.g., 'api.openai.com')."
+    - name: "model.port"
+      displayName: "Model Endpoint Port"
+      description: "Port for the external model endpoint"
+      type: "integer"
+      required: false
+      default: 443
+      llmGuidance: "Port for the external model endpoint. Typically 443 for cloud-hosted APIs. Only relevant when model.endpoint is set."
+    - name: "detectors.hap.useGpu"
+      displayName: "Enable GPU for HAP Detector"
+      description: "Enable GPU acceleration for the IBM HAP content safety detector"
+      type: "boolean"
+      required: false
+      default: false
+      llmGuidance: "Enable GPU acceleration for the HAP content safety detector. Only set to true if the cluster has additional GPU capacity beyond what the LLM requires. Improves inference speed but is not required for functionality."
+    - name: "detectors.promptInjection.useGpu"
+      displayName: "Enable GPU for Prompt Injection Detector"
+      description: "Enable GPU acceleration for the DeBERTa v3 prompt injection detector"
+      type: "boolean"
+      required: false
+      default: false
+      llmGuidance: "Enable GPU acceleration for the prompt injection detector. Same GPU capacity considerations as the HAP detector. Each detector enabled with GPU adds 1 nvidia.com/gpu to resource requirements."
+    - name: "gpu.tolerationKeys"
+      displayName: "GPU Taint Toleration Keys"
+      description: "Comma-separated list of Kubernetes taint keys for GPU node scheduling. Overrides auto-detection."
+      type: "string"
+      required: false
+      llmGuidance: "Only set this if the cluster uses non-standard taint keys on GPU nodes. By default, the installer auto-detects NoSchedule taints on GPU nodes. If the user provides a value (e.g., 'g5-gpu,g6e-gpu'), it completely replaces auto-detection. The standard default is 'nvidia.com/gpu'. Ask the user to check their cluster's GPU node taints if pods fail to schedule."
+
+status:
+  endpoint:
+    path: "/health"
+    description: "Returns health status of the lemonade stand chat application"
+  pollingInterval: "10s"
+  timeout: "20m"
+
+access:
+  endpoints:
+    - name: "lemonade-stand"
+      displayName: "Lemonade Stand Chat"
+      type: "route"
+      path: "/"
+      description: "Main AI-powered customer service chat interface"
+      public: true
+      authentication: "none"
+    - name: "shiny-dashboard"
+      displayName: "Monitoring Dashboard"
+      type: "route"
+      path: "/"
+      description: "Real-time Shiny dashboard showing guardrail metrics and request statistics"
+      public: true
+      authentication: "none"
+
+cleanup:
+  dataDescription: |
+    Detector model weights stored in MinIO (50 GiB PVC). No user data is persisted — chat
+    conversations are not saved. Dashboard metrics are held in-memory and reset on pod restart.
+  warning: |
+    Uninstalling will remove all deployed components including the MinIO storage with downloaded
+    detector models. A fresh install will need to re-download models from Huggingface (~5-10 minutes).
+
+documentation:
+  readme: "https://github.com/rh-ai-quickstart/lemonade-stand-assistant/blob/main/README.md"
+
+llmContext:
+  whenToRecommend: |
+    Recommend when users ask about AI safety, content moderation, guardrails for LLMs, building
+    safe customer-facing chatbots, or demonstrating TrustyAI capabilities. Also relevant when users
+    need a reference architecture for deploying multiple detector models alongside an LLM with
+    real-time content filtering.
+  faq:
+    - question: "Do I need a GPU?"
+      answer: "A GPU is required for the default deployment mode which runs Llama 3.2 locally. You can avoid the GPU requirement by bringing your own model endpoint (MaaS mode)."
+    - question: "How do I use my own model instead of Llama 3.2?"
+      answer: "Set model.name, model.endpoint, model.port, and model.api_key Helm values to point to any OpenAI-compatible API endpoint."
+    - question: "What guardrails are included?"
+      answer: "Three detectors: IBM Granite Guardian HAP 125M for harmful content, DeBERTa v3 for prompt injection detection, and Lingua for language identification. All run as separate inference services."
+    - question: "How long does deployment take?"
+      answer: "15-20 minutes. Most time is spent downloading detector models from Huggingface and waiting for inference services to become ready."
+    - question: "Can I add custom guardrails?"
+      answer: "The GuardrailsOrchestrator CRD from TrustyAI supports additional detectors. You can add new detector deployments and reference them in the orchestrator configuration."


### PR DESCRIPTION
The OpenShift navigator project aims to integrate quickstarts with OpenShift AI to enable users to discover and manage quickstart deployments using an agentic application (the navigator). The integration requires the following components which are included in this PR:

1. A quickstart-manifest.yaml file (and related schema.json) that consolidates quickstart metadata to support the navigator's decisions. This is added to each quickstart's project root. Please review the natural language descriptions of your quickstart in this file and adjust as you see fit. Please also update any minimum OpenShift versions you are targeting. I tested against OpenShift 4.21.16.

2. A containerized installer that runs on the customer's target cluster. The navigator deploys the installer on the target cluster as a kubernetes job. The installer is an abstraction over your existing helm based installation and ensures that different quickstarts always have the libraries and deployment tools they need regardless of the deployment technology they use (helm vs make vs. Kustomize, etc.).

In the process of fitting your quickstart for navigator integration, I encountered two specific issues that are fixed in this PR. Please review these fixes and rebuild the quickstart image on quay.io (otherwise the installer will not work).

Configurable GPU tolerations

The installer auto-detects NoSchedule taint keys on GPU nodes and converts them to Helm --set flags. Users can override with custom taint keys at install time. Chart templates use a gpuTolerations values list instead of hardcoded tolerations. Your quickstart had a specific toleration key which may not match what customers use on their target cluster, hence the chart was converted to make this configurable via values.yaml. 

Port mismatches in the orchestrator config

Orchestrator port fix (fms-orchestr8-config-nlp.yaml): KServe predictor services expose port 80, not the container target ports (8000/8080). Fixed llama-32-predictor, guardrails-detector-ibm-hap-predictor, and prompt-injection-detector-predictor entries. I'm not sure how this worked on other clusters (perhaps an older version of OpenShift allowed it), but the quickstart did not work on 4.21.16 with the configured ports. At some point in the orchestrator config git history, the ports were changed from the service port (which does work) to the container ports (which did not work on my dev cluster).  Chat UI showed "Connection error: network error" when orchestrator attempted to connect via container ports).

Test plan
 ./installer/build.sh push builds and pushes the installer image
 ./installer/deploy.sh check_pre_reqs <namespace> reports cluster prerequisites correctly (CPU in vCPU, memory in GiB, operators detected via CRDs, GPU taint keys listed)
 ./installer/deploy.sh install <namespace> deploys all components and GPU pods schedule successfully
 ./installer/deploy.sh status <namespace> reports pod readiness, Helm release status, InferenceService status, and route URLs
 ./installer/deploy.sh uninstall_delete_all <namespace> cleans up all resources and namespace

